### PR TITLE
言語リスト取得したら日本語にセットするように

### DIFF
--- a/src/translation/Translator.as
+++ b/src/translation/Translator.as
@@ -65,6 +65,7 @@ public class Translator {
 			languages = newLanguages;
 		}
 		Scratch.app.server.getLanguageList(saveLanguageList);
+		Translator.setLanguage('ja');
 	}
 
 	public static function setLanguageValue(lang:String):void {


### PR DESCRIPTION
po言語ファイルが無いとエラー出るかもしれないが、プロジェクト的には常に日本語poファイルがあるはずなので、問題無いと考える